### PR TITLE
Enable GraphQL in backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -44,6 +44,10 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
+## GraphQL Playground
+
+After starting the application, visit `http://localhost:3000/graphql` to explore the GraphQL API.
+
 ## Run tests
 
 ```bash

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,10 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/apollo": "^11.0.0",
+    "@nestjs/graphql": "^11.0.0",
+    "@apollo/server": "^4.9.0",
+    "graphql": "^16.8.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,18 @@
 import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AppResolver } from './app.resolver';
 
 @Module({
-  imports: [],
+  imports: [
+    GraphQLModule.forRoot<ApolloDriverConfig>({
+      driver: ApolloDriver,
+      autoSchemaFile: true,
+    }),
+  ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, AppResolver],
 })
 export class AppModule {}

--- a/backend/src/app.resolver.ts
+++ b/backend/src/app.resolver.ts
@@ -1,0 +1,12 @@
+import { Query, Resolver } from '@nestjs/graphql';
+import { AppService } from './app.service';
+
+@Resolver()
+export class AppResolver {
+  constructor(private readonly appService: AppService) {}
+
+  @Query(() => String)
+  hello(): string {
+    return this.appService.getHello();
+  }
+}


### PR DESCRIPTION
## Summary
- configure NestJS backend with GraphQL
- expose a simple `hello` query
- document GraphQL playground location

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ec834a0e483269f40b7ca85514387