### PR TITLE
Update frontend to run without nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ The services started are:
 
 - **db** – PostgreSQL database available on port 5432.
 - **backend** – NestJS application available on port 3000.
-- **frontend** – static frontend served with nginx on port 8080.
+- **frontend** – Next.js application served by Node on port 8080.
 
 The backend receives a `DATABASE_URL` environment variable pointing at the Postgres service.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: ./frontend
     ports:
-      - "8080:80"
+      - "8080:3000"
     depends_on:
       - backend
 volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,12 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-RUN if [ -f package.json ]; then npm install; fi
+RUN npm install
 COPY . .
-RUN if [ -f package.json ]; then npm run build; fi
+RUN npm run build
 
-FROM nginx:alpine
-COPY --from=build /app/build /usr/share/nginx/html
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app ./
+EXPOSE 3000
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- serve Next.js frontend via Node instead of nginx
- map host port 8080 to Next.js server
- document new setup

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ee44afb6c83269fc88791dce86d20