### PR TITLE
Add overlay for disabled admin items

### DIFF
--- a/frontend/src/app/admin/page.module.css
+++ b/frontend/src/app/admin/page.module.css
@@ -1,0 +1,22 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  position: relative;
+  padding: 16px;
+  border: 1px solid var(--gray-alpha-200, #ccc);
+  border-radius: 8px;
+  background: var(--background);
+}
+
+.disabled::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(128, 128, 128, 0.5);
+  border-radius: 8px;
+  pointer-events: none;
+}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,28 @@
+import styles from "./page.module.css";
+
+type Item = {
+  id: number;
+  name: string;
+  disabled?: boolean;
+};
+
+const items: Item[] = [
+  { id: 1, name: "Hotel Booking" },
+  { id: 2, name: "Room Service", disabled: true },
+  { id: 3, name: "Event Management" },
+];
+
+export default function AdminPage() {
+  return (
+    <div className={styles.grid}>
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className={`${styles.card} ${item.disabled ? styles.disabled : ""}`}
+        >
+          {item.name}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple admin page showing cards
- add overlay styling that activates when a card is disabled

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe9ad53f48326a772c46197051363